### PR TITLE
Emit re establishment fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pandular",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Angular module to re-establish a pan-domain auth (aka panda) session",
   "keywords": [
     "panda",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pandular",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "description": "Angular module to re-establish a pan-domain auth (aka panda) session",
   "keywords": [
     "panda",

--- a/src/heal.js
+++ b/src/heal.js
@@ -13,16 +13,18 @@ heal.config(['$provide', function ($provide) {
             return func().catch(error => {
                 // Check whether session has expired
                 if (error && error.status === 419) {
-                    $log.info('Invalid session, attempting to re-establish');
+                  $log.info('Invalid session, attempting to re-establish');
 
                   // Attempt to re-establish the session once before
                   return reEstablishSession().then(data => {
                         $log.info('Session re-established');
+                        $rootScope.$emit('pandular:re-establishment:success', data);
 
                         // Try again now we have a fresh session
                         return func();
                     }, sessionError => {
                         $log.error('Could not re-establish session: ' + sessionError);
+                        $rootScope.$emit('pandular:re-establishment:fail', sessionError);
 
                         // Note: we forward the *original* error we
                         // got from the server


### PR DESCRIPTION
So we can listen in from clients if, for some reason, the session bums out.
If this is alright I'll put a tech-debt in to perhaps store these event names somewhere else to be used by client and service.
