### PR TITLE
Make `pandular.reAuthTimeout` required config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pandular",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Angular module to re-establish a pan-domain auth (aka panda) session",
   "keywords": [
     "panda",

--- a/src/session.js
+++ b/src/session.js
@@ -14,10 +14,9 @@ export var session = angular.module('pandular.session', []);
 session.factory('pandular.reAuthUri', () => { throw new RequiredConfiguration('pandular.reAuthUri'); });
 
 /**
- * The number of milliseconds to wait for the session to re-establish
- * before giving up.
+ * The time to wait before giving up on re-auth 
  */
-session.constant('pandular.reAuthTimeout', 5000 /* ms */);
+session.factory('pandular.reAuthTimeout', () => { throw new RequiredConfiguration('pandular.reAuthTimeout'); });
 
 
 session.factory('pandular.reEstablishSession',


### PR DESCRIPTION
Previously this was hard-coded to 5000 millis, which may have been
causing problems with extremely high latency connections (e.g. EU ->
AUS).
